### PR TITLE
[ENH] Categorization of Participant_id, Session_id #13 

### DIFF
--- a/categorization/bin/P_id_S_id_Age_sex.py
+++ b/categorization/bin/P_id_S_id_Age_sex.py
@@ -1,22 +1,13 @@
+import json
 from typing import Dict
-
 from langchain_community.chat_models import ChatOllama
-from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_core.pydantic_v1 import BaseModel, Field
 
 def Categorize1(result_dict: Dict[str, str]) -> None:
 
      # Initialize model
     llm = ChatOllama(model="gemma")
-
-    # # Create output structure
-    # class ColumnCategorization(BaseModel):
-    #     predictedColumn: str = Field(description="Column name predicted by the LLM within the NB data model entities")
-
-    # # Set up parser
-    # parser = JsonOutputParser(pydantic_object=ColumnCategorization)
-
+     
     # Create prompt template
     prompt = PromptTemplate(
         template='''Given the column data {column}: {content}, determine the category and give only the category name as output
@@ -55,7 +46,14 @@ Output= <category> " "  "
         try:
             # Invoke the chain with the input data
             response = chain.invoke({"column": key, "content": value})
-            print("Response:", response)
+            r = str(response)
+            if "Subject_IDs" in r:
+                output = {"TermURL": "nb:ParticipantID"}
+                print(f"{json.dumps(output)}")
+            elif "Session_IDs" in r:
+                output = {"TermURL": "nb:Session"}
+                print(f"{json.dumps(output)}")
+
 
         except Exception as e:
             print("Error processing column:", key)

--- a/categorization/bin/P_id_S_id_Age_sex.py
+++ b/categorization/bin/P_id_S_id_Age_sex.py
@@ -1,0 +1,76 @@
+from typing import Dict
+
+from langchain_community.chat_models import ChatOllama
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import PromptTemplate
+from langchain_core.pydantic_v1 import BaseModel, Field
+
+def Categorize1(result_dict: Dict[str, str]) -> None:
+
+     # Initialize model
+    llm = ChatOllama(model="gemma")
+
+    # # Create output structure
+    # class ColumnCategorization(BaseModel):
+    #     predictedColumn: str = Field(description="Column name predicted by the LLM within the NB data model entities")
+
+    # # Set up parser
+    # parser = JsonOutputParser(pydantic_object=ColumnCategorization)
+
+    # Create prompt template
+    prompt = PromptTemplate(
+        template='''Given the column data {column}: {content}, determine the category and give only the category name as output
+
+Examples:
+1. Input: "participant_id: sub-01 sub-02 sub-03"
+   Output: Subject_IDs
+
+2. Input: 'pheno_age: ["34,1", "35,3", "NA", "39,0", "22,1", "23,2", "21,1", "22,3", "42,5", "43,2"]'
+   Output: Age
+
+3. Input: "session_id: ses-01 ses-02"
+   Output: Session_IDs
+
+4. Input: "pheno_sex : ["F", "F", "M", "M", "missing", "missing", "F", "F", "M", "M"]" 
+   Output: Sex
+
+5. Input: "pheno_sex : ["1", "2", "1", "2", "missing", "missing"]" 
+   Output: Sex
+
+Do Not Give any explanation in the output. 
+Input: "{column}: {content}"
+Output= <category> " "  "
+
+
+''',
+        input_variables=["column", "content"],
+    )
+
+    # Create chain
+    chain = prompt | llm 
+
+    # Process each column
+    for key, value in result_dict.items():
+        print("Processing column:", key)
+        try:
+            # Invoke the chain with the input data
+            response = chain.invoke({"column": key, "content": value})
+            print("Response:", response)
+
+        except Exception as e:
+            print("Error processing column:", key)
+            print("Error message:", e)
+
+
+
+if __name__ == "__main__":
+    result_dict = {
+        'participant_id': 'sub-01 sub-01 sub-02 sub-02 sub-03 sub-03 sub-04 sub-04 sub-05 sub-05',
+        'session_id': 'ses-01 ses-02 ses-01 ses-02 ses-01 ses-02 ses-01 ses-02 ses-01 ses-02',
+        'sex_column' : '[1, 2, 1, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2]',
+        'pheno_age': '34.1 35.3 nan 39.0 22.1 23.2 21.1 22.3 42.5 43.2',
+    
+    }
+
+    Categorize1(result_dict)
+   


### PR DESCRIPTION
- closes #13 and 


- Changes proposed in the pull request:   
The LLM ( the gemma model from Olama) performs categorizarion of columns, the input for the LLM is obtained from the                        parsing code where we have already obtained a dictionary from the tsv file.

- Follow up  that will be required:
1. Integrate the parsing code to obtained the dictionary
2. Refine the output inorder to easily integrate the llm output to the json file.


<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
